### PR TITLE
Upgrade candle and cudarc versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,37 +107,13 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "candle-core"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ccf5ee3532e66868516d9b315f73aec9f34ea1a37ae98514534d458915dbf1"
-dependencies = [
- "byteorder",
- "candle-kernels 0.8.4",
- "cudarc 0.13.9",
- "gemm 0.17.1",
- "half",
- "memmap2",
- "num-traits",
- "num_cpus",
- "rand",
- "rand_distr",
- "rayon",
- "safetensors",
- "thiserror",
- "ug 0.1.0",
- "ug-cuda 0.1.0",
- "yoke",
- "zip",
-]
-
-[[package]]
-name = "candle-core"
 version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f51e2ecf6efe9737af8f993433c839f956d2b6ed4fd2dd4a7c6d8b0fa667ff"
 dependencies = [
  "byteorder",
- "candle-kernels 0.9.1",
- "cudarc 0.16.6",
- "float8",
+ "candle-kernels",
+ "cudarc",
  "gemm 0.17.1",
  "half",
  "memmap2",
@@ -148,8 +124,8 @@ dependencies = [
  "rayon",
  "safetensors",
  "thiserror",
- "ug 0.4.0",
- "ug-cuda 0.4.0",
+ "ug",
+ "ug-cuda",
  "yoke",
  "zip",
 ]
@@ -158,8 +134,8 @@ dependencies = [
 name = "candle-cublaslt"
 version = "0.0.1"
 dependencies = [
- "candle-core 0.9.1",
- "cudarc 0.16.6",
+ "candle-core",
+ "cudarc",
  "half",
 ]
 
@@ -168,7 +144,7 @@ name = "candle-flash-attn-v1"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "candle-core 0.9.1",
+ "candle-core",
  "candle-nn",
  "half",
  "num_cpus",
@@ -177,16 +153,9 @@ dependencies = [
 
 [[package]]
 name = "candle-kernels"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10885bd902fad1b8518ba2b22369aaed88a3d94e123533ad3ca73db33b1c8ca"
-dependencies = [
- "bindgen_cuda",
-]
-
-[[package]]
-name = "candle-kernels"
 version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fcd989c2143aa754370b5bfee309e35fbd259e83d9ecf7a73d23d8508430775"
 dependencies = [
  "bindgen_cuda",
 ]
@@ -196,7 +165,7 @@ name = "candle-layer-norm"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "candle-core 0.8.4",
+ "candle-core",
  "half",
  "num_cpus",
  "rayon",
@@ -204,11 +173,11 @@ dependencies = [
 
 [[package]]
 name = "candle-nn"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1160c3b63f47d40d91110a3e1e1e566ae38edddbbf492a60b40ffc3bc1ff38"
+checksum = "c1980d53280c8f9e2c6cbe1785855d7ff8010208b46e21252b978badf13ad69d"
 dependencies = [
- "candle-core 0.8.4",
+ "candle-core",
  "half",
  "num-traits",
  "rayon",
@@ -223,7 +192,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "bindgen_cuda",
- "candle-core 0.9.1",
+ "candle-core",
  "candle-nn",
  "half",
 ]
@@ -273,16 +242,6 @@ name = "crunchy"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
-
-[[package]]
-name = "cudarc"
-version = "0.13.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486c221362668c63a1636cfa51463b09574433b39029326cff40864b3ba12b6e"
-dependencies = [
- "half",
- "libloading",
-]
 
 [[package]]
 name = "cudarc"
@@ -358,18 +317,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "float8"
-version = "0.2.1"
-source = "git+https://github.com/zackangelo/float8?branch=cudarc_0_16#03c1f5fe7cdb2f9cb690823fdd40593be57c408f"
-dependencies = [
- "cudarc 0.16.6",
- "half",
- "num-traits",
- "rand",
- "rand_distr",
-]
 
 [[package]]
 name = "gemm"
@@ -1207,27 +1154,6 @@ dependencies = [
 
 [[package]]
 name = "ug"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03719c61a91b51541f076dfdba45caacf750b230cefaa4b32d6f5411c3f7f437"
-dependencies = [
- "gemm 0.18.2",
- "half",
- "libloading",
- "memmap2",
- "num",
- "num-traits",
- "num_cpus",
- "rayon",
- "safetensors",
- "serde",
- "thiserror",
- "tracing",
- "yoke",
-]
-
-[[package]]
-name = "ug"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b70b37e9074642bc5f60bb23247fd072a84314ca9e71cdf8527593406a0dd3"
@@ -1249,28 +1175,15 @@ dependencies = [
 
 [[package]]
 name = "ug-cuda"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50758486d7941f8b0a636ba7e29455c07071f41590beac1fd307ec893e8db69a"
-dependencies = [
- "cudarc 0.13.9",
- "half",
- "serde",
- "thiserror",
- "ug 0.1.0",
-]
-
-[[package]]
-name = "ug-cuda"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14053653d0b7fa7b21015aa9a62edc8af2f60aa6f9c54e66386ecce55f22ed29"
 dependencies = [
- "cudarc 0.16.6",
+ "cudarc",
  "half",
  "serde",
  "thiserror",
- "ug 0.4.0",
+ "ug",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,8 +112,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ccf5ee3532e66868516d9b315f73aec9f34ea1a37ae98514534d458915dbf1"
 dependencies = [
  "byteorder",
- "candle-kernels",
- "cudarc",
+ "candle-kernels 0.8.4",
+ "cudarc 0.13.9",
  "gemm 0.17.1",
  "half",
  "memmap2",
@@ -124,8 +124,32 @@ dependencies = [
  "rayon",
  "safetensors",
  "thiserror",
- "ug",
- "ug-cuda",
+ "ug 0.1.0",
+ "ug-cuda 0.1.0",
+ "yoke",
+ "zip",
+]
+
+[[package]]
+name = "candle-core"
+version = "0.9.1"
+dependencies = [
+ "byteorder",
+ "candle-kernels 0.9.1",
+ "cudarc 0.16.6",
+ "float8",
+ "gemm 0.17.1",
+ "half",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "rand",
+ "rand_distr",
+ "rayon",
+ "safetensors",
+ "thiserror",
+ "ug 0.4.0",
+ "ug-cuda 0.4.0",
  "yoke",
  "zip",
 ]
@@ -134,8 +158,8 @@ dependencies = [
 name = "candle-cublaslt"
 version = "0.0.1"
 dependencies = [
- "candle-core",
- "cudarc",
+ "candle-core 0.9.1",
+ "cudarc 0.16.6",
  "half",
 ]
 
@@ -144,7 +168,7 @@ name = "candle-flash-attn-v1"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "candle-core",
+ "candle-core 0.9.1",
  "candle-nn",
  "half",
  "num_cpus",
@@ -161,11 +185,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "candle-kernels"
+version = "0.9.1"
+dependencies = [
+ "bindgen_cuda",
+]
+
+[[package]]
 name = "candle-layer-norm"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "candle-core",
+ "candle-core 0.8.4",
  "half",
  "num_cpus",
  "rayon",
@@ -177,7 +208,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1160c3b63f47d40d91110a3e1e1e566ae38edddbbf492a60b40ffc3bc1ff38"
 dependencies = [
- "candle-core",
+ "candle-core 0.8.4",
  "half",
  "num-traits",
  "rayon",
@@ -192,7 +223,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "bindgen_cuda",
- "candle-core",
+ "candle-core 0.9.1",
  "candle-nn",
  "half",
 ]
@@ -248,6 +279,16 @@ name = "cudarc"
 version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486c221362668c63a1636cfa51463b09574433b39029326cff40864b3ba12b6e"
+dependencies = [
+ "half",
+ "libloading",
+]
+
+[[package]]
+name = "cudarc"
+version = "0.16.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17200eb07e7d85a243aa1bf4569a7aa998385ba98d14833973a817a63cc86e92"
 dependencies = [
  "half",
  "libloading",
@@ -317,6 +358,18 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "float8"
+version = "0.2.1"
+source = "git+https://github.com/zackangelo/float8?branch=cudarc_0_16#03c1f5fe7cdb2f9cb690823fdd40593be57c408f"
+dependencies = [
+ "cudarc 0.16.6",
+ "half",
+ "num-traits",
+ "rand",
+ "rand_distr",
+]
 
 [[package]]
 name = "gemm"
@@ -1174,16 +1227,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ug"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b70b37e9074642bc5f60bb23247fd072a84314ca9e71cdf8527593406a0dd3"
+dependencies = [
+ "gemm 0.18.2",
+ "half",
+ "libloading",
+ "memmap2",
+ "num",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "safetensors",
+ "serde",
+ "thiserror",
+ "tracing",
+ "yoke",
+]
+
+[[package]]
 name = "ug-cuda"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50758486d7941f8b0a636ba7e29455c07071f41590beac1fd307ec893e8db69a"
 dependencies = [
- "cudarc",
+ "cudarc 0.13.9",
  "half",
  "serde",
  "thiserror",
- "ug",
+ "ug 0.1.0",
+]
+
+[[package]]
+name = "ug-cuda"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14053653d0b7fa7b21015aa9a62edc8af2f60aa6f9c54e66386ecce55f22ed29"
+dependencies = [
+ "cudarc 0.16.6",
+ "half",
+ "serde",
+ "thiserror",
+ "ug 0.4.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,12 +29,10 @@ cudarc = { version = ">=0.16.0", default-features = false, features = [
 ] }
 half = { version = "2.3.1", features = ["num-traits"] }
 # Dev
-candle-nn = { version = "0.*", features = ["cuda"] }
+candle-nn = { version = ">=0.9", features = ["cuda"] }
 # Build
 anyhow = { version = "1", features = ["backtrace"] }
 bindgen_cuda = "0.1.1"
 num_cpus = "1.15.0"
 rayon = "1.7.0"
-candle = { path = "../candle/candle-core", package = "candle-core", features = [
-    "cuda",
-] }
+candle = { version = ">=0.9", package = "candle-core", features = ["cuda"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = [
-    "candle-layer-norm", 
-    "candle-rotary", 
+    "candle-layer-norm",
+    "candle-rotary",
     "candle-flash-attn-v1",
     "candle-cublaslt",
 ]
@@ -19,8 +19,14 @@ repository = "https://github.com/huggingface/candle-extensions/"
 
 [workspace.dependencies]
 # Runtime
-candle = { version = "0.*", package = "candle-core", features = ["cuda"]}
-cudarc = { version = "0.*" }
+cudarc = { version = ">=0.16.0", default-features = false, features = [
+    "std",
+    "cublaslt",
+    "driver",
+    "f16",
+    "cuda-version-from-build-system",
+    "dynamic-linking",
+] }
 half = { version = "2.3.1", features = ["num-traits"] }
 # Dev
 candle-nn = { version = "0.*", features = ["cuda"] }
@@ -29,3 +35,6 @@ anyhow = { version = "1", features = ["backtrace"] }
 bindgen_cuda = "0.1.1"
 num_cpus = "1.15.0"
 rayon = "1.7.0"
+candle = { path = "../candle/candle-core", package = "candle-core", features = [
+    "cuda",
+] }

--- a/candle-cublaslt/src/lib.rs
+++ b/candle-cublaslt/src/lib.rs
@@ -2,7 +2,6 @@ pub use cudarc::cublaslt::Activation;
 use std::ffi::c_int;
 
 use candle::backend::BackendStorage;
-use candle::cuda_backend::WrapErr;
 use candle::{CpuStorage, Device, Layout, Result, Shape, Storage, Tensor};
 use half::{bf16, f16};
 use std::sync::Arc;
@@ -14,12 +13,12 @@ pub struct CublasLt(Arc<CudaBlasLT>);
 
 impl CublasLt {
     pub fn new(device: &Device) -> Result<Self> {
-        let dev = match device {
-            Device::Cuda(d) => d,
+        let stream = match device {
+            Device::Cuda(d) => d.cuda_stream(),
             _ => candle::bail!("`device` must be a `cuda` device"),
         };
 
-        let inner = CudaBlasLT::new(dev.cuda_device()).unwrap();
+        let inner = CudaBlasLT::new(stream).unwrap();
 
         Ok(Self(Arc::new(inner)))
     }
@@ -47,7 +46,6 @@ impl CublasLTMatmul {
 
         // Assume TN
         let (m, k) = a_l.shape().dims2()?;
-
         let (n, b_1) = b_l.shape().dims2()?;
 
         if b_1 != k {
@@ -97,12 +95,13 @@ impl CublasLTMatmul {
             c.clone()
         } else {
             // Allocate out tensor
-            unsafe { dev.alloc::<f16>(out_shape.elem_count()).w()? }
+            unsafe { dev.alloc::<f16>(out_shape.elem_count())? }
         };
 
         let config = MatmulConfig {
             transa: true,
             transb: false,
+            transc: false,
             m: m as u64,
             n: n as u64,
             k: k as u64,
@@ -192,12 +191,13 @@ impl CublasLTMatmul {
             c.clone()
         } else {
             // Allocate out tensor
-            unsafe { dev.alloc::<bf16>(out_shape.elem_count()).w()? }
+            unsafe { dev.alloc::<bf16>(out_shape.elem_count())? }
         };
 
         let config = MatmulConfig {
             transa: true,
             transb: false,
+            transc: false,
             m: m as u64,
             n: n as u64,
             k: k as u64,
@@ -287,12 +287,13 @@ impl CublasLTMatmul {
             c.clone()
         } else {
             // Allocate out tensor
-            unsafe { dev.alloc::<f32>(out_shape.elem_count()).w()? }
+            unsafe { dev.alloc::<f32>(out_shape.elem_count())? }
         };
 
         let config = MatmulConfig {
             transa: true,
             transb: false,
+            transc: false,
             m: m as u64,
             n: n as u64,
             k: k as u64,
@@ -505,7 +506,7 @@ impl CublasLTBatchMatmul {
         } else {
             // Allocate out tensor
             (
-                unsafe { dev.alloc::<f16>(out_shape.elem_count()).w()? },
+                unsafe { dev.alloc::<f16>(out_shape.elem_count())? },
                 (n * m),
             )
         };
@@ -513,6 +514,7 @@ impl CublasLTBatchMatmul {
         let config = MatmulConfig {
             transa: true,
             transb: false,
+            transc: false,
             m: m as u64,
             n: n as u64,
             k: k as u64,
@@ -608,7 +610,7 @@ impl CublasLTBatchMatmul {
         } else {
             // Allocate out tensor
             (
-                unsafe { dev.alloc::<bf16>(out_shape.elem_count()).w()? },
+                unsafe { dev.alloc::<bf16>(out_shape.elem_count())? },
                 (n * m),
             )
         };
@@ -616,6 +618,7 @@ impl CublasLTBatchMatmul {
         let config = MatmulConfig {
             transa: true,
             transb: false,
+            transc: false,
             m: m as u64,
             n: n as u64,
             k: k as u64,
@@ -711,7 +714,7 @@ impl CublasLTBatchMatmul {
         } else {
             // Allocate out tensor
             (
-                unsafe { dev.alloc::<f32>(out_shape.elem_count()).w()? },
+                unsafe { dev.alloc::<f32>(out_shape.elem_count())? },
                 (n * m),
             )
         };
@@ -719,6 +722,7 @@ impl CublasLTBatchMatmul {
         let config = MatmulConfig {
             transa: true,
             transb: false,
+            transc: false,
             m: m as u64,
             n: n as u64,
             k: k as u64,

--- a/candle-layer-norm/src/lib.rs
+++ b/candle-layer-norm/src/lib.rs
@@ -1,6 +1,7 @@
 mod ffi;
 
 use candle::backend::BackendStorage;
+use candle::cuda::cudarc::driver::SyncOnDrop;
 use candle::cuda_backend::cudarc::driver::sys::CUdevice_attribute::CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT;
 use candle::cuda_backend::cudarc::driver::DevicePtr;
 use candle::cuda_backend::WrapErr;
@@ -41,6 +42,7 @@ impl LayerNorm {
     ) -> Result<(candle::CudaStorage, Shape)> {
         // Assume all tensors are on the same device and take device of x
         let dev = x.device();
+        let stream = dev.cuda_stream();
 
         // Get internal layer norm type id for the given dtype
         let layer_norm_type = layer_norm_internal_type(x.dtype())?;
@@ -96,30 +98,34 @@ impl LayerNorm {
         let is_rms_norm = if self.is_rms_norm { 1 } else { 0 };
 
         // If beta is et, get ids device pointer
-        let b_ptr = if let Some(beta) = &self.beta {
-            // Make sure that beta is a CUDA tensor and get the underlying storage
-            let (b, b_l) = beta.storage_and_layout();
-            let b = match &*b {
-                Storage::Cuda(b) => b,
-                _ => candle::bail!("gamma must be a cuda tensor"),
+        let beta_ptr: Option<(*const std::ffi::c_void, SyncOnDrop<'_>)> =
+            if let Some(beta) = &self.beta {
+                // Make sure that beta is a CUDA tensor and get the underlying storage
+                let (b, b_l) = beta.storage_and_layout();
+                let (s, p, g) = match &*b {
+                    Storage::Cuda(b) => {
+                        let b = b.as_cuda_slice::<T>()?;
+                        let b_slice = b.slice(b_l.start_offset()..);
+                        let b_stride = b_l.stride();
+                        let b_rank = b_stride.len();
+
+                        if b_stride[b_rank - 1] != 1 {
+                            candle::bail!("the last dim of b must be contiguous {b_stride:?}")
+                        }
+
+                        let (p, g) = b_slice.device_ptr(&stream);
+                        (b_slice, p, g)
+                    }
+                    _ => candle::bail!("gamma must be a cuda tensor"),
+                };
+
+                Some((p as *const std::ffi::c_void, g))
+            } else {
+                None
             };
 
-            let b = b.as_cuda_slice::<T>()?;
-            let b = b.slice(b_l.start_offset()..);
-
-            let b_stride = b_l.stride();
-            let b_rank = b_stride.len();
-
-            if b_stride[b_rank - 1] != 1 {
-                candle::bail!("the last dim of b must be contiguous {b_stride:?}")
-            }
-            *b.device_ptr() as *const core::ffi::c_void
-        } else {
-            ptr::null() as *const std::ffi::c_void
-        };
-
         // If residual is set, get its device pointer
-        let r_ptr = if let (Some(r), Some(r_l)) = (r, r_l) {
+        let (r_ptr, _r_ptr_guard) = if let (Some(r), Some(r_l)) = (r, r_l) {
             // Check shape
             let expected_shape = x_l.shape().dims2()?;
             if r_l.shape().dims2()? != expected_shape {
@@ -139,46 +145,52 @@ impl LayerNorm {
             if r_stride[r_rank - 1] != 1 {
                 candle::bail!("the last dim of r must be contiguous {r_stride:?}")
             }
-            *r.device_ptr() as *const std::ffi::c_void
+
+            let (p, g) = r.device_ptr(&stream); // as *const std::ffi::c_void
+
+            (p as *const std::ffi::c_void, Some(g))
         } else {
-            ptr::null() as *const std::ffi::c_void
+            (ptr::null() as *const std::ffi::c_void, None)
         };
 
         // We will store the results of the residual add next to the main results
         // so out has the same shape as inp * 2
         let out_shape = Shape::from((rows * 2, cols));
 
-        let out = unsafe { dev.alloc::<T>(out_shape.elem_count()) }.w()?;
+        let out = unsafe { dev.alloc::<T>(out_shape.elem_count()) }?;
         let dst = out.slice(..rows * cols);
         let dst_add = out.slice(rows * cols..);
 
         // Alloc internal buffers
-        let mu = unsafe { dev.alloc::<f32>(rows) }.w()?;
-        let rsigma = unsafe { dev.alloc::<f32>(rows) }.w()?;
+        let mu = unsafe { dev.alloc::<f32>(rows) }?;
+        let rsigma = unsafe { dev.alloc::<f32>(rows) }?;
 
         // Get cuda device pointers from cuda slices
-        let x_ptr = *x.device_ptr() as *const core::ffi::c_void;
-        let g_ptr = *g.device_ptr() as *const core::ffi::c_void;
-        let dst_add_ptr = *dst_add.device_ptr() as *const core::ffi::c_void;
-        let dst_ptr = *dst.device_ptr() as *const core::ffi::c_void;
-        let mu_ptr = *mu.device_ptr() as *const core::ffi::c_void;
-        let rsigma_ptr = *rsigma.device_ptr() as *const core::ffi::c_void;
+        let (x_ptr, _x_ptr_guard) = x.device_ptr(&stream); // as *const core::ffi::c_void
+        let (g_ptr, _g_ptr_guard) = g.device_ptr(&stream); // as *const core::ffi::c_void
+        let (dst_add_ptr, _dst_add_ptr_guard) = dst_add.device_ptr(&stream); // as *const core::ffi::c_void
+        let (dst_ptr, _dst_ptr_guard) = dst.device_ptr(&stream); // as *const core::ffi::c_void
+        let (mu_ptr, _mu_ptr_guard) = mu.device_ptr(&stream); // as *const core::ffi::c_void
+        let (rsigma_ptr, _rsigma_ptr_guard) = rsigma.device_ptr(&stream); // as *const core::ffi::c_void
 
-        let multi_processors_count = dev
+        let multi_processors_count = stream
+            .context()
             .attribute(CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT)
             .unwrap();
 
         unsafe {
             // Launch Kernel
             ffi::run_ln(
-                x_ptr,
-                r_ptr,
-                g_ptr,
-                b_ptr,
-                dst_add_ptr,
-                dst_ptr,
-                mu_ptr,
-                rsigma_ptr,
+                x_ptr as *const std::ffi::c_void,
+                r_ptr as *const std::ffi::c_void,
+                g_ptr as *const std::ffi::c_void,
+                beta_ptr
+                    .map(|(p, _)| p as *const std::ffi::c_void)
+                    .unwrap_or(ptr::null()),
+                dst_add_ptr as *const std::ffi::c_void,
+                dst_ptr as *const std::ffi::c_void,
+                mu_ptr as *const std::ffi::c_void,
+                rsigma_ptr as *const std::ffi::c_void,
                 self.epsilon,
                 cols_rounded as u32,
                 rows as u32,

--- a/candle-rotary/src/lib.rs
+++ b/candle-rotary/src/lib.rs
@@ -32,6 +32,8 @@ fn apply_rotary_<
         _ => candle::bail!("query must be a cuda tensor"),
     };
 
+    let stream = query.device().as_cuda_device().unwrap().cuda_stream();
+
     let (k, k_l) = key.storage_and_layout();
     let k = match &*k {
         Storage::Cuda(k) => k,
@@ -102,19 +104,21 @@ fn apply_rotary_<
     let query_stride = q_l.stride()[0];
     let key_stride = k_l.stride()[0];
 
-    let q_ptr = *q.device_ptr() as *const core::ffi::c_void;
-    let k_ptr = *k.device_ptr() as *const core::ffi::c_void;
-    let cc_ptr = *cc.device_ptr() as *const core::ffi::c_void;
-    let sc_ptr = *sc.device_ptr() as *const core::ffi::c_void;
+    //as *const core::ffi::c_void
+
+    let (q_ptr, _q_ptr_guard) = q.device_ptr(&stream);
+    let (k_ptr, _k_ptr_guard) = k.device_ptr(&stream);
+    let (cc_ptr, _cc_ptr_guard) = cc.device_ptr(&stream);
+    let (sc_ptr, _sc_ptr_guard) = sc.device_ptr(&stream);
 
     let neox = if is_neox { 1 } else { 0 };
 
     unsafe {
         ffi::rotary_embedding(
-            q_ptr,
-            k_ptr,
-            cc_ptr,
-            sc_ptr,
+            q_ptr as *const core::ffi::c_void,
+            k_ptr as *const core::ffi::c_void,
+            cc_ptr as *const core::ffi::c_void,
+            sc_ptr as *const core::ffi::c_void,
             neox,
             head_size as c_int,
             num_tokens as c_long,


### PR DESCRIPTION
Still WIP, new cudarc version makes it difficult to deal with optional tensors and device pointers, need to fix and clean up that logic in candle-layernorm.